### PR TITLE
Bugfix/missing default telnet port

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -42,6 +42,7 @@
           "port": {
             "title": "Port",
             "type": "integer",
+            "default": 23,
             "placeholder": 23,
             "description": "Default port for telnet is 23, set as appropriate for your device."
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-extron-matrix-switch",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-extron-matrix-switch",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "telnet-client": "2.2.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "displayName": "Extron Matrix Switch",
   "name": "homebridge-extron-matrix-switch",
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A plugin to control your Extron Matrix switch via HomeBridge.",
   "author": "Joe Baumgartner",
   "license": "Apache-2.0",

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,7 +26,7 @@ export async function telnetResponse(telnetParams: { hostname: string; port: num
 
   const params = {
     host: telnetParams.hostname,
-    port: telnetParams.port,
+    port: telnetParams.port ?? 23,
     negotiationMandatory: false,
   };
 


### PR DESCRIPTION
Configuration now requires a port to be defined. This defaults it to 23 if the user never specifies anything.